### PR TITLE
Make Verify part of Action optional

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 /cover.out
 pkg/build/jvm/testdata/jvm/target/
 .gradle/
+.vscode/

--- a/README.md
+++ b/README.md
@@ -376,6 +376,7 @@ The Following inputs can be used as `step.with` keys
 | `repo_dir`              | String | $GITHUB_WORKSPACE                 | **Internal value (do not set):** Root of directory to look for build files                                                                              | False    |
 | `github_context`        | String | ${{ toJSON(github) }}             | **Internal value (do not set):** the [github context](#github-context) object in json                                                                   | False    |
 | `runner_context`        | String | ${{ toJSON(runner) }}             | **Internal value (do not set):** the [runner context](#runner-context) object in json                                                                   | False    |
+| `verify_attestation`    | String | "true"                            |  A boolean for enabling or disabling the verify stage of the attestation.                                                           | False    |
 
 ### Outputs
 

--- a/action.yml
+++ b/action.yml
@@ -114,7 +114,7 @@ inputs:
 
 runs:
   using: "docker"
-  image: "docker://ghcr.io/nais/salsa:v0.9"
+  image: "Dockerfile" # TODO Revert after testing action
   args:
     - ${{ inputs.repo_dir }}
     - ${{ inputs.repo_name }}

--- a/action.yml
+++ b/action.yml
@@ -1,10 +1,9 @@
-name: 'nais SLSA Provenance Action'
-description: 'Action to generate signed SLSA provenance'
+name: "nais SLSA Provenance Action"
+description: "Action to generate signed SLSA provenance"
 branding:
   icon: lock
   color: red
 inputs:
-
   registry:
     description: |-
       Registry to push to
@@ -59,6 +58,12 @@ inputs:
     required: false
     default: ""
 
+  verify_attestation:
+    description: |-
+      A boolean for enabling or disabling the verify stage of the attestation.
+    required: false
+    default: "true"
+
   github_token:
     description: |-
       Normal use is "GITHUB_TOKEN". To fetch from private repository use
@@ -108,8 +113,8 @@ inputs:
     default: ${{ toJSON(runner) }}
 
 runs:
-  using: 'docker'
-  image: 'docker://ghcr.io/nais/salsa:v0.9'
+  using: "docker"
+  image: "docker://ghcr.io/nais/salsa:v0.9"
   args:
     - ${{ inputs.repo_dir }}
     - ${{ inputs.repo_name }}
@@ -123,9 +128,9 @@ runs:
     - ${{ inputs.mvn_opts }}
     - ${{ inputs.github_token }}
     - ${{ inputs.docker_user }}
-    - ${{ inputs.github_token }}
     - ${{ inputs.token_key_pattern }}
     - ${{ inputs.build_started_on }}
     - ${{ inputs.registry_access_token }}
     - ${{ inputs.registry }}
     - ${{ inputs.image_digest }}
+    - ${{ inputs.verify_attestation }}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,7 +1,7 @@
 #!/bin/sh -l
 
 setup() {
-  echo "---------- Preparing pico-de-galo SLSA ----------"
+  echo "---------- Preparing pico de gallo SLSA ----------"
 
   REPO_NAME="${INPUT_REPO_NAME##*/}"
   if [ -z "$REPO_NAME" ]; then
@@ -15,7 +15,7 @@ setup() {
   fi
 
   if [ -n "$INPUT_DOCKER_USER" ]; then
-    export GITHUB_ACTOR=$INPUT_DOCKER_USER
+    export GITHUB_ACTOR="$INPUT_DOCKER_USER"
   fi
 
   if [ -z "$GITHUB_ACTOR" ]; then
@@ -24,7 +24,7 @@ setup() {
   fi
 
   if [ -n "$INPUT_IMAGE" ]; then
-    export IMAGE=$INPUT_IMAGE
+    export IMAGE="$INPUT_IMAGE"
   fi
 
   if [ -z "$INPUT_IMAGE_DIGEST" ] || [ -z "$IMAGE" ]; then
@@ -36,6 +36,13 @@ setup() {
 
   if [ -z "$INPUT_GITHUB_CONTEXT" ] || [ -z "$INPUT_RUNNER_CONTEXT" ]; then
     echo "GITHUB_CONTEXT and RUNNER_CONTEXT are required"
+    exit 1
+  fi
+
+  if [ "$INPUT_VERIFY_ATTESTATION" = "false" ] && [ -z "$INPUT_KEY" ]; then
+    echo "When running keyless salsa you must verify the attestation. Please set the verify_attestation flag to 'true'.
+    
+    (This is also the default value, and may instead be omitted)."
     exit 1
   fi
 
@@ -86,19 +93,20 @@ logoutDocker() {
 }
 
 scan() {
-  salsa scan \
-    --repo "$REPO_NAME" \
-    --build-context "$GITHUB" \
-    --runner-context "$RUNNER" \
-    --env-context "$ENVS" \
-    --subDir "$INPUT_REPO_SUB_DIR" \
-    --mvn-opts "$INPUT_MVN_OPTS" \
-    --build-started-on "$INPUT_BUILD_STARTED_ON" \
-    --remote-run
+  echo "---------- Running Salsa scan for deps ----------" &&
+    salsa scan \
+      --repo "$REPO_NAME" \
+      --build-context "$GITHUB" \
+      --runner-context "$RUNNER" \
+      --env-context "$ENVS" \
+      --subDir "$INPUT_REPO_SUB_DIR" \
+      --mvn-opts "$INPUT_MVN_OPTS" \
+      --build-started-on "$INPUT_BUILD_STARTED_ON" \
+      --remote-run
 }
 
 attest() {
-  echo "create and upload attestation" &&
+  echo "---------- Creating and Uploading Salsa attestation ----------" &&
     salsa attest \
       --repo "$REPO_NAME" \
       --subDir "$INPUT_REPO_SUB_DIR" \
@@ -109,7 +117,7 @@ attest() {
 }
 
 attestVerify() {
-  echo "verify attestation" &&
+  echo "---------- Verifying Salsa attestation ----------" &&
     salsa attest \
       --verify \
       --repo "$REPO_NAME" \
@@ -120,8 +128,13 @@ attestVerify() {
 }
 
 runSalsa() {
-  echo "---------- Running Salsa for repository: $REPO_NAME ----------" &&
+  echo "---------- Running Salsa for repository: $REPO_NAME ----------"
+  if [ "$INPUT_VERIFY_ATTESTATION" = "true" ]; then
+    scan && attest
+  elif [ "$INPUT_VERIFY_ATTESTATION" = "false" ]; then
     scan && attest && attestVerify
+  fi
+
 }
 
 cleanUpGoogle() {


### PR DESCRIPTION
Can now set a flag `verify_attestation` which defaults to true. If set to false, the action will skip the verify stage.

Also fixes some bash stuff, some formatting, and adds cleaner feedback to user for stages in action.